### PR TITLE
Various small enhancements and a bug fix

### DIFF
--- a/dzapi.py
+++ b/dzapi.py
@@ -70,6 +70,10 @@ class DeezerAPI:
         return resp['results']
 
     def login_via_email(self, email, password):
+
+        if not self.client_id or not self.client_secret:
+            raise self.exception('client_id/client_secret setting is empty or missing, check settings.json')
+
         # server sends set-cookie header with anonymous sid
         self.s.get('https://www.deezer.com')
         
@@ -99,7 +103,15 @@ class DeezerAPI:
         if not user_data['USER']['USER_ID']:
             self.s.cookies.clear()
             raise self.exception('Invalid arl')
-        print('ARL Country : ', self.country)
+        
+        if len(self.country) == 2:
+            code_point_1 = ord(self.country[0]) + 127397
+            code_point_2 = ord(self.country[1]) + 127397
+            country_flag = chr(code_point_1) + chr(code_point_2)
+        else:
+            country_flag = ''
+
+        print(f"ARL Country: {self.country} {country_flag} - Available Formats: {' | '.join(self.available_formats)}")
         return user_data
 
     def get_track(self, id):

--- a/dzapi.py
+++ b/dzapi.py
@@ -200,7 +200,8 @@ class DeezerAPI:
     def _get_blowfish_key(self, track_id):
         # yeah, you use the bytes of the hex digest of the hash. bruh moment
         md5_id = MD5.new(str(track_id).encode()).hexdigest().encode('ascii')
-
+        if not self.bf_secret:
+            raise self.exception('bf_secret missing or empty, check config.json')
         key = bytes([md5_id[i] ^ md5_id[i + 16] ^ self.bf_secret[i] for i in range(16)])
 
         return key


### PR DESCRIPTION
- Fixes "AttributeError: 'DeezerAPI' object has no attribute 'language'" when trying to login with only an ARL on a fresh install

- Display ARL country flag and available formats of that account
- Added priority for config ARL over stored one to easily swap between ARLs (without removing loginstorage.bin)
- Print if using email/password or arl to login the first time

- Errors if bf_secret is missing or empty
- Errors when id/secret are missing or empty from the config
- Errors if arl/credentials are missing or empty on config